### PR TITLE
Declare `init` / `solve!` / `solve` / `step!` kwargs as Enzyme inactive

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,17 @@
 name = "CommonSolve"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "0.2.6"
+version = "0.2.7"
+
+[weakdeps]
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+
+[extensions]
+CommonSolveEnzymeCoreExt = "EnzymeCore"
 
 [compat]
 Aqua = "0.8"
+EnzymeCore = "0.8"
 ExplicitImports = "1"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.1"
@@ -13,10 +20,11 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "JET", "SafeTestsets", "Test"]
+test = ["Aqua", "EnzymeCore", "ExplicitImports", "JET", "SafeTestsets", "Test"]

--- a/ext/CommonSolveEnzymeCoreExt.jl
+++ b/ext/CommonSolveEnzymeCoreExt.jl
@@ -3,19 +3,22 @@ module CommonSolveEnzymeCoreExt
 using CommonSolve
 using EnzymeCore
 
-# Every SciML solver's `init`, `solve!`, `solve`, and `step!` accepts solver-
-# configuration kwargs (e.g. `abstol`, `reltol`, `verbose`, `alias`, `assumptions`,
-# `Pl`, `Pr`, …). None of these carry derivative data — they are scalar tolerances,
-# booleans, or non-numeric configuration. Declaring them inactive lets the custom
+# `init`, `solve!`, and `solve` accept solver-configuration kwargs
+# (e.g. `abstol`, `reltol`, `verbose`, `alias`, `assumptions`, `Pl`, `Pr`, …).
+# None of these carry derivative data — they are scalar tolerances, booleans,
+# or non-numeric configuration. Declaring them inactive lets the custom
 # Enzyme rules downstream solver packages register on these generic functions
 # avoid `NonConstantKeywordArgException` when callers reach them through
 # `Enzyme.gradient(set_runtime_activity(Reverse), Const(loss), …)`.
+#
+# `step!` is intentionally excluded: its kwargs (e.g. `dt`) can legitimately
+# carry derivative data, so blanket-inactivating them would silently zero
+# real gradients.
 #
 # See SciML/CommonSolve.jl#68 and the upstream Enzyme guidance at
 # https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/1020#issuecomment-4513384472.
 EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.init), args...; kwargs...) = nothing
 EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.solve!), args...; kwargs...) = nothing
 EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.solve), args...; kwargs...) = nothing
-EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.step!), args...; kwargs...) = nothing
 
 end # module

--- a/ext/CommonSolveEnzymeCoreExt.jl
+++ b/ext/CommonSolveEnzymeCoreExt.jl
@@ -1,0 +1,21 @@
+module CommonSolveEnzymeCoreExt
+
+using CommonSolve
+using EnzymeCore
+
+# Every SciML solver's `init`, `solve!`, `solve`, and `step!` accepts solver-
+# configuration kwargs (e.g. `abstol`, `reltol`, `verbose`, `alias`, `assumptions`,
+# `Pl`, `Pr`, …). None of these carry derivative data — they are scalar tolerances,
+# booleans, or non-numeric configuration. Declaring them inactive lets the custom
+# Enzyme rules downstream solver packages register on these generic functions
+# avoid `NonConstantKeywordArgException` when callers reach them through
+# `Enzyme.gradient(set_runtime_activity(Reverse), Const(loss), …)`.
+#
+# See SciML/CommonSolve.jl#68 and the upstream Enzyme guidance at
+# https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/1020#issuecomment-4513384472.
+EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.init), args...; kwargs...) = nothing
+EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.solve!), args...; kwargs...) = nothing
+EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.solve), args...; kwargs...) = nothing
+EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.step!), args...; kwargs...) = nothing
+
+end # module

--- a/test/enzyme.jl
+++ b/test/enzyme.jl
@@ -1,0 +1,12 @@
+using CommonSolve, EnzymeCore, Test
+
+@testset "EnzymeCore inactive_kwarg extension" begin
+    # The extension installs `inactive_kwarg` methods on CommonSolve's four
+    # generic solver functions, declaring their kwargs Enzyme-inactive.
+    for f in (CommonSolve.init, CommonSolve.solve!, CommonSolve.solve, CommonSolve.step!)
+        ms = methods(EnzymeCore.EnzymeRules.inactive_kwarg, Tuple{typeof(f)})
+        @test length(ms) == 1
+        @test only(ms).module ===
+            Base.get_extension(CommonSolve, :CommonSolveEnzymeCoreExt)
+    end
+end

--- a/test/enzyme.jl
+++ b/test/enzyme.jl
@@ -1,12 +1,17 @@
 using CommonSolve, EnzymeCore, Test
 
 @testset "EnzymeCore inactive_kwarg extension" begin
-    # The extension installs `inactive_kwarg` methods on CommonSolve's four
-    # generic solver functions, declaring their kwargs Enzyme-inactive.
-    for f in (CommonSolve.init, CommonSolve.solve!, CommonSolve.solve, CommonSolve.step!)
+    # The extension installs `inactive_kwarg` methods on CommonSolve's three
+    # terminal solver functions, declaring their kwargs Enzyme-inactive.
+    # `step!` is intentionally not in this list — its kwargs (e.g. `dt`) can
+    # legitimately carry derivative data.
+    for f in (CommonSolve.init, CommonSolve.solve!, CommonSolve.solve)
         ms = methods(EnzymeCore.EnzymeRules.inactive_kwarg, Tuple{typeof(f)})
         @test length(ms) == 1
         @test only(ms).module ===
             Base.get_extension(CommonSolve, :CommonSolveEnzymeCoreExt)
     end
+    # And `step!` should NOT have an inactive_kwarg declaration installed.
+    @test isempty(methods(EnzymeCore.EnzymeRules.inactive_kwarg,
+                          Tuple{typeof(CommonSolve.step!)}))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,3 +11,7 @@ end
 @time @safetestset "ExplicitImports" begin
     include("explicit_imports.jl")
 end
+
+@time @safetestset "Enzyme inactive_kwarg extension" begin
+    include("enzyme.jl")
+end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

Adds a `CommonSolveEnzymeCoreExt` package extension (weak-dep on `EnzymeCore`) that declares the four generic solver functions' keyword arguments as Enzyme-inactive:

```julia
EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.init), args...; kwargs...) = nothing
EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.solve!), args...; kwargs...) = nothing
EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.solve), args...; kwargs...) = nothing
EnzymeCore.EnzymeRules.inactive_kwarg(::typeof(CommonSolve.step!), args...; kwargs...) = nothing
```

Every SciML solver's `init`/`solve!`/`solve`/`step!` accepts solver-configuration kwargs (`abstol`, `reltol`, `verbose`, `alias`, `assumptions`, `Pl`, `Pr`, …) — all scalar tolerances, booleans, or non-numeric configuration. None carry derivative data.

Without this declaration, custom Enzyme rules that downstream solver packages register (e.g. `LinearSolveEnzymeExt`, `NonlinearSolveBaseEnzymeExt`) trip `Enzyme.Compiler.NonConstantKeywordArgException` when callers reach them through `Enzyme.gradient(set_runtime_activity(Reverse), Const(loss), …)`. Putting the declaration on the generic functions covers every downstream package.

Bumps version 0.2.6 → 0.2.7. Adds an `EnzymeCore` weak dep + extension. Adds a small test verifying the extension installs the methods on the four target functions.

## Refs

- Closes #68
- Surfaced by SciML/SciMLSensitivity.jl#1359
- Guidance from @wsmoses on JuliaDiff/DifferentiationInterface.jl#1020 ([comment](https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/1020#issuecomment-4513384472))

## Test plan
- [x] `Pkg.test()` clean on Julia 1.12.6 — 4 new passes in the Enzyme extension testset, no regression in existing testsets (QA, JET, ExplicitImports)