### PR TITLE
Declare solve/solve!/init/step! public

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CommonSolve"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "0.2.8"
+version = "0.2.9"
 
 [compat]
 SafeTestsets = "0.1"

--- a/src/CommonSolve.jl
+++ b/src/CommonSolve.jl
@@ -72,4 +72,15 @@ the iterator for, and are implementation-specific.
 """
 function step! end
 
+# `solve`, `solve!`, `init`, `step!` are CommonSolve's entire public API — each is
+# documented above and is the canonical interface downstream solvers import and
+# extend. They are intentionally NOT exported (to avoid `using`-scope clashes with
+# the many packages that define their own `solve`/`init`/...), so mark them
+# `public` so tooling (ExplicitImports) and users recognize them as API.
+# `eval(Expr(:public, ...))` keeps this file parsing on the pre-1.11 floor where
+# the `public` keyword does not yet exist.
+@static if VERSION >= v"1.11.0-DEV.469"
+    eval(Expr(:public, :solve, :solve!, :init, :step!))
+end
+
 end # module


### PR DESCRIPTION
Mark CommonSolve's four verbs (solve, solve!, init, step!) as public API (Julia 1.11+, via eval(Expr(:public,…)) to keep parsing on the pre-1.11 floor); not exported, to avoid using-scope clashes. Each is documented and is the canonical solver interface every downstream imports/extends, but they were neither exported nor public-declared — so ExplicitImports' public-API checks flag every downstream qualified access (e.g. SciMLBase #1397 ignore-lists init/solve/solve!/step!). Once released, every downstream drops that ignore. Verified public on 1.12, loads clean on 1.10; Runic-clean; version 0.2.8->0.2.9. Ignore until reviewed by @ChrisRackauckas.