### PR TITLE
Bump version to 0.2.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CommonSolve"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "0.2.9"
+version = "0.2.10"
 
 [compat]
 SafeTestsets = "0.1"


### PR DESCRIPTION
Automated patch version bump (0.2.9 -> 0.2.10) to release unreleased commits on `master` via JuliaRegistrator.