### PR TITLE
Release prep: bump CommonSolve to 0.2.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CommonSolve"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "0.2.10"
+version = "0.2.11"
 
 [compat]
 SafeTestsets = "0.1"


### PR DESCRIPTION
Patch release to register accumulated docstring/QA/test-scaffolding changes since 0.2.10 (module docstring, Documenter @autodocs block, test-only SciMLTesting compat bump). No functional/API changes.