### PR TITLE
Remove stale DiffEqBase downstream job

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceI}
-          - {user: SciML, repo: SciMLBase.jl, group: Core}
-          - {user: SciML, repo: DiffEqBase.jl, group: Core}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: "", group: InterfaceI}
+          - {user: SciML, repo: SciMLBase.jl, subdir: "", group: Core}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Core}
         os:
           - ubuntu-latest
           - macos-latest
@@ -34,6 +34,7 @@ jobs:
       julia-version: "1"
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
+      subdir: "${{ matrix.package.subdir }}"
       group: "${{ matrix.package.group }}"
       os: "${{ matrix.os }}"
     secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -22,9 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: "", group: InterfaceI}
-          - {user: SciML, repo: SciMLBase.jl, subdir: "", group: Core}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Core}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceI}
+          - {user: SciML, repo: SciMLBase.jl, group: Core}
         os:
           - ubuntu-latest
           - macos-latest
@@ -34,7 +33,6 @@ jobs:
       julia-version: "1"
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
-      subdir: "${{ matrix.package.subdir }}"
       group: "${{ matrix.package.group }}"
       os: "${{ matrix.os }}"
     secrets: "inherit"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- remove the stale DiffEqBase downstream row
- retain the two relevant downstream integrations: OrdinaryDiffEq `InterfaceI` and SciMLBase `Core`

DiffEqBase moved into the OrdinaryDiffEq monorepo, but retargeting the old row to `lib/DiffEqBase` was not sufficient: the migrated package no longer declares or references CommonSolve in its project, source, or tests. Running DiffEqBase's Core group would therefore execute tests without exercising this upstream package. The earlier retargeting commit is deliberately superseded by the final deletion.

## Local verification

- `actionlint .github/workflows/Downstream.yml` (exit 0)
- `julia +1.12 --startup-file=no -m Runic --check .` (exit 0)
- `git diff --check` (exit 0)
- a recursive `rg` assertion over `lib/DiffEqBase/Project.toml`, `src/`, and `test/` found no CommonSolve declaration or reference

The branch is current with upstream `master`.

The PR should be ignored until reviewed by @ChrisRackauckas.