### PR TITLE
Enable CommonSolve rendered docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,3 @@
 using SciMLTesting, CommonSolve, JET, Test
 
-run_qa(CommonSolve; explicit_imports = true)
+run_qa(CommonSolve; api_docs_kwargs = (; rendered = true), explicit_imports = true)


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Enable SciMLTesting rendered public API docs QA for CommonSolve.
- No docs page or docstring changes were needed; the existing API page already renders the package-owned public API.

## Validation
- `git diff --check` passed.
- QA passed with `api_docs_kwargs = (; rendered = true)`: Quality Assurance 18/18.
- `Pkg.test()` passed: `Core/core_tests.jl` 9/9.
- `include("docs/make.jl")` passed; Documenter only emitted the expected local deployment skip warning.
- Runic v1.7.0 passed over `src`, `test`, and `docs`.

Note: `Pkg.test()` printed the existing manifest-staleness warning after syncing current `master`; this PR does not change manifests.
