### PR TITLE
Document and test generic solver interface

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(
     sitename = "CommonSolve.jl",
     authors = "Chris Rackauckas",
     modules = [CommonSolve],
-    clean = true, doctest = false, linkcheck = true,
+    clean = true, linkcheck = true,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/CommonSolve/stable"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,17 +39,17 @@ In such cases, the `step!` function can be used:
 step!(::SolverType, args...; kwargs...)
 ```
 
-To avoid method ambiguity, the first argument of `solve`, `solve!`, `step!`, and `init`
-_must_ be dispatched on a type defined in your package. For example, do
-_not_ define a method such as
+To avoid type piracy and method ambiguity, the first argument of `solve`, `solve!`, `step!`,
+and `init` _must_ be dispatched on a type defined in your package. For example, do _not_
+define a method such as
 
 ```julia
 init(::AbstractVector, ::AlgorithmType)
 ```
 
-where `AlgorithmType` is your type but `AbstractVector` is not. Instead, either the
-problem or the algorithm type must be defined in your package to avoid type piracy and
-method ambiguities with other packages.
+where `AlgorithmType` is your type but `AbstractVector` is not. The first argument must be
+your problem or iterator type; placing an owned algorithm type in a later argument is not
+sufficient.
 
 ## API
 

--- a/src/CommonSolve.jl
+++ b/src/CommonSolve.jl
@@ -32,7 +32,7 @@ module CommonSolve
 
 """
 ```julia
-CommonSolve.solve(args...; kwargs...)
+CommonSolve.solve(args...; kwargs...) -> solution
 ```
 
 Solve an equation or other mathematical problem using the algorithm specified
@@ -48,16 +48,25 @@ If a package only defines the iterator interface, `solve` falls back to:
 solve(args...; kwargs...) = solve!(init(args...; kwargs...))
 ```
 
-## Arguments
+# Arguments
 
-  - `args...`: Problem, algorithm, and implementation-specific positional arguments.
-  - `kwargs...`: Implementation-specific solver options.
+- `args...`: Problem, algorithm, and implementation-specific positional arguments.
 
-## Returns
+# Keywords
+
+- `kwargs...`: Implementation-specific solver options.
+
+# Interface
+
+Extensions must dispatch the first positional argument on a type that they own.
+This prevents type piracy and ambiguities between independently developed solver
+packages.
+
+# Returns
 
 The solution object defined by the downstream solver implementation.
 
-## Example
+# Examples
 
 ```julia
 struct MyProblem end
@@ -72,7 +81,7 @@ solve(args...; kwargs...) = solve!(init(args...; kwargs...))
 
 """
 ```julia
-CommonSolve.solve!(iter)
+CommonSolve.solve!(iter) -> solution
 ```
 
 Complete the solve using an iterator or cache object created by
@@ -83,15 +92,16 @@ iter = CommonSolve.init(prob::ProblemType, alg::SolverType; kwargs...)::IterType
 CommonSolve.solve!(iter)::SolutionType
 ```
 
-## Arguments
+# Arguments
 
-  - `iter`: Solver state returned by `CommonSolve.init`.
+- `iter`: Solver state returned by `CommonSolve.init`. Its type must be owned by the
+  package extending `solve!`.
 
-## Returns
+# Returns
 
 The solution object defined by the downstream solver implementation.
 
-## Example
+# Examples
 
 ```julia
 struct MyIterator end
@@ -105,7 +115,7 @@ function solve! end
 
 """
 ```julia
-iter = CommonSolve.init(args...; kwargs...)
+CommonSolve.init(args...; kwargs...) -> iter
 ```
 
 Create an iterator or cache object that can be passed to
@@ -117,16 +127,20 @@ iter = CommonSolve.init(prob::ProblemType, alg::SolverType; kwargs...)::IterType
 CommonSolve.solve!(iter)::SolutionType
 ```
 
-## Arguments
+# Arguments
 
-  - `args...`: Problem, algorithm, and implementation-specific positional arguments.
-  - `kwargs...`: Implementation-specific solver options.
+- `args...`: Problem, algorithm, and implementation-specific positional arguments. The
+  first positional argument must have a type owned by the package extending `init`.
 
-## Returns
+# Keywords
+
+- `kwargs...`: Implementation-specific solver options.
+
+# Returns
 
 An implementation-defined iterator or cache object that stores solver state.
 
-## Example
+# Examples
 
 ```julia
 struct MyProblem end
@@ -142,25 +156,29 @@ function init end
 
 """
 ```julia
-CommonSolve.step!(iter, args...; kwargs...)
+CommonSolve.step!(iter, args...; kwargs...) -> step_result
 ```
 
 Progress an iterator or cache object returned by [`CommonSolve.init`](@ref).
 The additional arguments typically describe how far to advance the solve and
 are implementation-specific.
 
-## Arguments
+# Arguments
 
-  - `iter`: Solver state returned by `CommonSolve.init`.
+- `iter`: Solver state returned by `CommonSolve.init`. Its type must be owned by the
+  package extending `step!`.
   - `args...`: Implementation-specific step controls.
-  - `kwargs...`: Implementation-specific step options.
 
-## Returns
+# Keywords
+
+- `kwargs...`: Implementation-specific step options.
+
+# Returns
 
 An implementation-defined value, commonly the updated iterator, a step result,
 or `nothing`.
 
-## Example
+# Examples
 
 ```julia
 mutable struct MyIterator

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -3,28 +3,28 @@ using Test
 
 module GenericSolverInterfaceTest
 
-using CommonSolve
+    using CommonSolve
 
-struct Problem
-    initial_value::Int
-end
+    struct Problem
+        initial_value::Int
+    end
 
-struct IterativeAlgorithm end
-struct DirectAlgorithm end
+    struct IterativeAlgorithm end
+    struct DirectAlgorithm end
 
-mutable struct Iterator
-    value::Int
-end
+    mutable struct Iterator
+        value::Int
+    end
 
-CommonSolve.init(problem::Problem, ::IterativeAlgorithm; offset = 0) =
-    Iterator(problem.initial_value + offset)
-CommonSolve.solve!(iter::Iterator) = iter.value
-function CommonSolve.step!(iter::Iterator; increment = 1)
-    iter.value += increment
-    return iter
-end
-CommonSolve.solve(problem::Problem, ::DirectAlgorithm; offset = 0) =
-    problem.initial_value + offset
+    CommonSolve.init(problem::Problem, ::IterativeAlgorithm; offset = 0) =
+        Iterator(problem.initial_value + offset)
+    CommonSolve.solve!(iter::Iterator) = iter.value
+    function CommonSolve.step!(iter::Iterator; increment = 1)
+        iter.value += increment
+        return iter
+    end
+    CommonSolve.solve(problem::Problem, ::DirectAlgorithm; offset = 0) =
+        problem.initial_value + offset
 
 end
 

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -1,6 +1,33 @@
 using CommonSolve
 using Test
 
+module GenericSolverInterfaceTest
+
+using CommonSolve
+
+struct Problem
+    initial_value::Int
+end
+
+struct IterativeAlgorithm end
+struct DirectAlgorithm end
+
+mutable struct Iterator
+    value::Int
+end
+
+CommonSolve.init(problem::Problem, ::IterativeAlgorithm; offset = 0) =
+    Iterator(problem.initial_value + offset)
+CommonSolve.solve!(iter::Iterator) = iter.value
+function CommonSolve.step!(iter::Iterator; increment = 1)
+    iter.value += increment
+    return iter
+end
+CommonSolve.solve(problem::Problem, ::DirectAlgorithm; offset = 0) =
+    problem.initial_value + offset
+
+end
+
 @testset "CommonSolve.jl" begin
     # CommonSolve is a pure interface package. There is no behavior to exercise
     # beyond confirming the package loads and its public interface is declared
@@ -21,4 +48,19 @@ using Test
             @test Base.ispublic(CommonSolve, name)
         end
     end
+end
+
+@testset "Generic solver interface" begin
+    problem = GenericSolverInterfaceTest.Problem(2)
+    iterative_algorithm = GenericSolverInterfaceTest.IterativeAlgorithm()
+
+    # `solve`'s generic fallback composes only the public `init` and `solve!` functions.
+    @test CommonSolve.solve(problem, iterative_algorithm; offset = 3) == 5
+
+    iter = CommonSolve.init(problem, iterative_algorithm; offset = 1)
+    @test CommonSolve.step!(iter; increment = 4) === iter
+    @test CommonSolve.solve!(iter) == 7
+
+    direct_algorithm = GenericSolverInterfaceTest.DirectAlgorithm()
+    @test CommonSolve.solve(problem, direct_algorithm; offset = 3) == 5
 end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,3 @@
 using SciMLTesting, CommonSolve, JET, Test
 
-run_qa(CommonSolve; api_docs_kwargs = (; rendered = true), explicit_imports = true)
+run_qa(CommonSolve; explicit_imports = true)


### PR DESCRIPTION
## Summary
- document the first-argument ownership rule at every CommonSolve extension point
- add executable coverage of the generic `init -> solve!` fallback, direct `solve`, and `step!` interface
- remove the repository-specific QA API-docs override and Documenter doctest disablement

## Validation
- Runic
- `Pkg.test()` (`13/13`)
- standard SciMLTesting QA
- docs build with Documenter doctests enabled

Ignore until reviewed by @ChrisRackauckas.