### PR TITLE
Bump CommonSolve to v0.2.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CommonSolve"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "0.2.11"
+version = "0.2.12"
 
 [compat]
 SafeTestsets = "0.1"


### PR DESCRIPTION
Bumps `CommonSolve` **v0.2.11 → v0.2.12** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Update SciMLTesting compat to 2.4 (#87) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)