### PR TITLE
Enable strict documentation QA

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,8 @@ makedocs(
     authors = "Chris Rackauckas",
     modules = [CommonSolve],
     clean = true, linkcheck = true,
+    doctest = true,
+    checkdocs = :exports,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/CommonSolve/stable"


### PR DESCRIPTION
## Summary
- enable Documenter doctests
- enforce exported API documentation with `checkdocs = :exports`

## Verification
- `Pkg.test()` (18/18 passed)
- strict SciMLTesting QA subprocess
- `docs/make.jl` with doctests and exported API checks
- Runic and `git diff --check`

Ignore until reviewed by @ChrisRackauckas.