### PR TITLE
Fix step! docstring argument nesting

### DIFF
--- a/src/CommonSolve.jl
+++ b/src/CommonSolve.jl
@@ -167,7 +167,7 @@ are implementation-specific.
 
 - `iter`: Solver state returned by `CommonSolve.init`. Its type must be owned by the
   package extending `step!`.
-  - `args...`: Implementation-specific step controls.
+- `args...`: Implementation-specific step controls.
 
 # Keywords
 


### PR DESCRIPTION
## Summary
- render `args...` as a sibling of `iter` in the `CommonSolve.step!` argument list

## Validation
- `/home/crackauc/.juliaup/bin/julia +1.12 --project=docs docs/make.jl`
- Runic check
- `git diff --check`

Ignore until reviewed by @ChrisRackauckas.