### PR TITLE
Add PrecompileTools workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,11 @@ uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "0.2.13"
 
+[deps]
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+
 [compat]
+PrecompileTools = "1.2.1"
 SafeTestsets = "0.1"
 SciMLTesting = "2.4"
 Test = "1"

--- a/src/CommonSolve.jl
+++ b/src/CommonSolve.jl
@@ -30,6 +30,8 @@ CommonSolve.solve(MyProblem(), MyAlg())
 """
 module CommonSolve
 
+using PrecompileTools: @compile_workload
+
 """
 ```julia
 CommonSolve.solve(args...; kwargs...) -> solution
@@ -194,6 +196,24 @@ iter = CommonSolve.step!(MyIterator(0))
 ```
 """
 function step! end
+
+# Private fixtures exercise the fallback without modeling a downstream solver.
+struct _PrecompileProblem end
+struct _PrecompileAlgorithm end
+struct _PrecompileIterator end
+
+init(::_PrecompileProblem, ::_PrecompileAlgorithm) = _PrecompileIterator()
+solve!(::_PrecompileIterator) = nothing
+step!(::_PrecompileIterator) = nothing
+
+@compile_workload begin
+    problem = _PrecompileProblem()
+    algorithm = _PrecompileAlgorithm()
+    iter = init(problem, algorithm)
+    solve(problem, algorithm)
+    step!(iter)
+    solve!(iter)
+end
 
 # `solve`, `solve!`, `init`, `step!` are CommonSolve's entire public API — each is
 # documented above and is the canonical interface downstream solvers import and


### PR DESCRIPTION
## Summary
Adds a PrecompileTools workload covering representative public APIs so the package common execution path is compiled during precompilation.

## Verification
The branch was validated locally with package load/precompile, a focused workload smoke test, and repository checks where available. Runic, typos, and git diff --check were checked for the change.

## Known limitations
No additional limitation was observed in the focused verification.

This draft should be ignored until reviewed by @ChrisRackauckas.